### PR TITLE
Capabilities based auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ vendor/*/
 .idea/
 *.iml
 ggr
+ggr.exe
 cover.*

--- a/docs/cli-flags.adoc
+++ b/docs/cli-flags.adoc
@@ -2,12 +2,18 @@
 
 The following flags are supported by ```ggr``` command:
 ```
+  -authentication-method string
+        How users should be authenticated. Possible choices are: basic, capabilities
   -listen string
     	host and port to listen to (default ":4444")
+  -password-field string
+        Name of the field in the capabilities that users must put their password into.
   -quotaDir string
     	quota directory (default "quota")
   -timeout duration
     	session creation timeout in time.Duration format, e.g. 300s or 500ms (default 5m0s)
+  -username-field string
+        Name of the field in the capabilities that users must put their username into.
   -users string
     	htpasswd auth file path (default ".htpasswd")
   -version

--- a/main.go
+++ b/main.go
@@ -25,10 +25,17 @@ var (
 	startTime      = time.Now()
 	lastReloadTime = time.Now()
 
+	authenticationMethod string
+	userNameField string
+	passwordField string
+
 	version     bool
 	gitRevision string = "HEAD"
 	buildStamp  string = "unknown"
 )
+
+const basicAuthentication string = "basic"
+const capabilitiesBasedAuthentication string = "capabilities"
 
 func loadQuotaFiles(quotaDir string) error {
 	log.Printf("Loading configuration files from [%s]\n", quotaDir)
@@ -83,7 +90,21 @@ func init() {
 	flag.DurationVar(&timeout, "timeout", 300*time.Second, "session creation timeout in time.Duration format, e.g. 300s or 500ms")
 	flag.DurationVar(&gracefulPeriod, "graceful-period", 300*time.Second, "graceful shutdown period in time.Duration format, e.g. 300s or 500ms")
 	flag.BoolVar(&version, "version", false, "show version and exit")
+
+	flag.StringVar(&authenticationMethod, "authentication-method", basicAuthentication, fmt.Sprintf("How users should be authenticated. Possible choices are: %s,%s", basicAuthentication, capabilitiesBasedAuthentication ))
+	flag.StringVar(&userNameField, "username-field", "user", "Name of the field in the capabilities that users must put their username into.")
+	flag.StringVar(&passwordField, "password-field", "password", "Name of the field in the capabilities that users must put their password into.")
 	flag.Parse()
+
+	switch authenticationMethod {
+	case basicAuthentication:
+	case capabilitiesBasedAuthentication:
+		break;
+	default:
+		log.Fatalf("Authentication method [%s] is not valid\n", authenticationMethod)
+		os.Exit(1);
+	}
+
 	if version {
 		showVersion()
 		os.Exit(0)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -666,6 +666,84 @@ func TestStartSessionBrowserFailWrongMsg(t *testing.T) {
 	AssertThat(t, rsp, AllOf{Code{http.StatusInternalServerError}, Message{"cannot create session browser-1.0 on any hosts after 1 attempt(s)"}})
 }
 
+func TestStartSessionCapabilitiesAuthentication(t *testing.T) {
+
+	authenticationMethod = capabilitiesBasedAuthentication;
+	srv = httptest.NewServer(mux());
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/wd/hub/session", postOnly(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"value":{"sessionId":"123"}}`))
+	}))
+	selenium := httptest.NewServer(mux)
+	defer selenium.Close()
+
+	host, port := hostportnum(selenium.URL)
+	node := Host{Name: host, Port: port, Count: 1}
+
+	test.Lock()
+	defer test.Unlock()
+
+	browsers := Browsers{Browsers: []Browser{
+		{Name: "{browser}", DefaultVersion: "1.0", Versions: []Version{
+			{Number: "1.0", Regions: []Region{
+				{Hosts: Hosts{
+					node,
+				}},
+			}},
+		}}}}
+	updateQuota(user, browsers)
+
+	rsp, err := createSessionWithoutAuthentication(`{"desiredCapabilities":{"browserName":"{browser}", "version":"1.0", "user":"test","password":"test"  }}`)
+
+	AssertThat(t, err, Is{nil})
+	var value map[string]interface{}
+	AssertThat(t, rsp, AllOf{Code{http.StatusOK}, IsJson{&value}})
+	AssertThat(t, value["value"].(map[string]interface{})["sessionId"], EqualTo{fmt.Sprintf("%s123", node.sum())})
+}
+
+func TestStartSessionCapabilitiesAuthenticationBadPassword(t *testing.T) {
+
+	authenticationMethod = capabilitiesBasedAuthentication;
+	srv = httptest.NewServer(mux());
+	mux := http.NewServeMux()
+	mux.HandleFunc("/wd/hub/session", postOnly(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"value":{"sessionId":"123"}}`))
+	}))
+	selenium := httptest.NewServer(mux)
+	defer selenium.Close()
+
+	host, port := hostportnum(selenium.URL)
+	node := Host{Name: host, Port: port, Count: 1}
+
+	test.Lock()
+	defer test.Unlock()
+
+	browsers := Browsers{Browsers: []Browser{
+		{Name: "{browser}", DefaultVersion: "1.0", Versions: []Version{
+			{Number: "1.0", Regions: []Region{
+				{Hosts: Hosts{
+					node,
+				}},
+			}},
+		}}}}
+	updateQuota(user, browsers)
+
+	rsp, _ := createSessionWithoutAuthentication(`{"desiredCapabilities":{"browserName":"{browser}", "version":"1.0", "user":"test","password":"BAD-PASSWORD"  }}`)
+	AssertThat(t, rsp,  AllOf{Code{http.StatusUnauthorized}})
+}
+
+func createSessionWithoutAuthentication(capabilities string) (*http.Response, error) {
+	body := bytes.NewReader([]byte(capabilities))
+	return doHTTPRequestWithouAuthentication(http.MethodPost, gridrouter("/wd/hub/session"), body)
+}
+
+func doHTTPRequestWithouAuthentication(method string, url string, body io.Reader) (*http.Response, error) {
+	req, _ := http.NewRequest(method, url, body)
+	client := &http.Client{}
+	return client.Do(req)
+}
+
 func TestStartSessionFailJSONWireProtocol(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/wd/hub/session", postOnly(func(w http.ResponseWriter, r *http.Request) {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -666,83 +666,6 @@ func TestStartSessionBrowserFailWrongMsg(t *testing.T) {
 	AssertThat(t, rsp, AllOf{Code{http.StatusInternalServerError}, Message{"cannot create session browser-1.0 on any hosts after 1 attempt(s)"}})
 }
 
-func TestStartSessionCapabilitiesAuthentication(t *testing.T) {
-
-	authenticationMethod = capabilitiesBasedAuthentication;
-	srv = httptest.NewServer(mux());
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/wd/hub/session", postOnly(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"value":{"sessionId":"123"}}`))
-	}))
-	selenium := httptest.NewServer(mux)
-	defer selenium.Close()
-
-	host, port := hostportnum(selenium.URL)
-	node := Host{Name: host, Port: port, Count: 1}
-
-	test.Lock()
-	defer test.Unlock()
-
-	browsers := Browsers{Browsers: []Browser{
-		{Name: "{browser}", DefaultVersion: "1.0", Versions: []Version{
-			{Number: "1.0", Regions: []Region{
-				{Hosts: Hosts{
-					node,
-				}},
-			}},
-		}}}}
-	updateQuota(user, browsers)
-
-	rsp, err := createSessionWithoutAuthentication(`{"desiredCapabilities":{"browserName":"{browser}", "version":"1.0", "user":"test","password":"test"  }}`)
-
-	AssertThat(t, err, Is{nil})
-	var value map[string]interface{}
-	AssertThat(t, rsp, AllOf{Code{http.StatusOK}, IsJson{&value}})
-	AssertThat(t, value["value"].(map[string]interface{})["sessionId"], EqualTo{fmt.Sprintf("%s123", node.sum())})
-}
-
-func TestStartSessionCapabilitiesAuthenticationBadPassword(t *testing.T) {
-
-	authenticationMethod = capabilitiesBasedAuthentication;
-	srv = httptest.NewServer(mux());
-	mux := http.NewServeMux()
-	mux.HandleFunc("/wd/hub/session", postOnly(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"value":{"sessionId":"123"}}`))
-	}))
-	selenium := httptest.NewServer(mux)
-	defer selenium.Close()
-
-	host, port := hostportnum(selenium.URL)
-	node := Host{Name: host, Port: port, Count: 1}
-
-	test.Lock()
-	defer test.Unlock()
-
-	browsers := Browsers{Browsers: []Browser{
-		{Name: "{browser}", DefaultVersion: "1.0", Versions: []Version{
-			{Number: "1.0", Regions: []Region{
-				{Hosts: Hosts{
-					node,
-				}},
-			}},
-		}}}}
-	updateQuota(user, browsers)
-
-	rsp, _ := createSessionWithoutAuthentication(`{"desiredCapabilities":{"browserName":"{browser}", "version":"1.0", "user":"test","password":"BAD-PASSWORD"  }}`)
-	AssertThat(t, rsp,  AllOf{Code{http.StatusUnauthorized}})
-}
-
-func createSessionWithoutAuthentication(capabilities string) (*http.Response, error) {
-	body := bytes.NewReader([]byte(capabilities))
-	return doHTTPRequestWithouAuthentication(http.MethodPost, gridrouter("/wd/hub/session"), body)
-}
-
-func doHTTPRequestWithouAuthentication(method string, url string, body io.Reader) (*http.Response, error) {
-	req, _ := http.NewRequest(method, url, body)
-	client := &http.Client{}
-	return client.Do(req)
-}
 
 func TestStartSessionFailJSONWireProtocol(t *testing.T) {
 	mux := http.NewServeMux()
@@ -1072,4 +995,82 @@ func TestStartSessionProxyHeaders(t *testing.T) {
 	var sess map[string]string
 	AssertThat(t, rsp, AllOf{Code{http.StatusOK}, IsJson{&sess}})
 	AssertThat(t, sess["sessionId"], EqualTo{fmt.Sprintf("%s123", node.sum())})
+}
+
+func TestStartSessionCapabilitiesAuthentication(t *testing.T) {
+
+	authenticationMethod = capabilitiesBasedAuthentication;
+	srv = httptest.NewServer(mux());
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/wd/hub/session", postOnly(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"value":{"sessionId":"123"}}`))
+	}))
+	selenium := httptest.NewServer(mux)
+	defer selenium.Close()
+
+	host, port := hostportnum(selenium.URL)
+	node := Host{Name: host, Port: port, Count: 1}
+
+	test.Lock()
+	defer test.Unlock()
+
+	browsers := Browsers{Browsers: []Browser{
+		{Name: "{browser}", DefaultVersion: "1.0", Versions: []Version{
+			{Number: "1.0", Regions: []Region{
+				{Hosts: Hosts{
+					node,
+				}},
+			}},
+		}}}}
+	updateQuota(user, browsers)
+
+	rsp, err := createSessionWithoutAuthentication(`{"desiredCapabilities":{"browserName":"{browser}", "version":"1.0", "user":"test","password":"test"  }}`)
+	AssertThat(t, err, Is{nil})
+	var value map[string]interface{}
+	AssertThat(t, rsp, AllOf{Code{http.StatusOK}, IsJson{&value}})
+	AssertThat(t, value["value"].(map[string]interface{})["sessionId"], EqualTo{fmt.Sprintf("%s123", node.sum())})
+}
+
+func TestStartSessionCapabilitiesAuthenticationBadPassword(t *testing.T) {
+
+	authenticationMethod = capabilitiesBasedAuthentication;
+	srv = httptest.NewServer(mux());
+	mux := http.NewServeMux()
+	mux.HandleFunc("/wd/hub/session", postOnly(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"value":{"sessionId":"123"}}`))
+	}))
+	selenium := httptest.NewServer(mux)
+	defer selenium.Close()
+
+	host, port := hostportnum(selenium.URL)
+	node := Host{Name: host, Port: port, Count: 1}
+
+	test.Lock()
+	defer test.Unlock()
+
+	browsers := Browsers{Browsers: []Browser{
+		{Name: "{browser}", DefaultVersion: "1.0", Versions: []Version{
+			{Number: "1.0", Regions: []Region{
+				{Hosts: Hosts{
+					node,
+				}},
+			}},
+		}}}}
+	updateQuota(user, browsers)
+
+	rsp, _ := createSessionWithoutAuthentication(`{"desiredCapabilities":{"browserName":"{browser}", "version":"1.0", "user":"test","password":"BAD-PASSWORD"  }}`)
+	authenticationMethod = basicAuthentication
+	AssertThat(t, rsp,  AllOf{Code{http.StatusUnauthorized}})
+}
+
+func createSessionWithoutAuthentication(capabilities string) (*http.Response, error) {
+	body := bytes.NewReader([]byte(capabilities))
+	return doHTTPRequestWithouAuthentication(http.MethodPost, gridrouter("/wd/hub/session"), body)
+}
+
+func doHTTPRequestWithouAuthentication(method string, url string, body io.Reader) (*http.Response, error) {
+	req, _ := http.NewRequest(method, url, body)
+	client := &http.Client{}
+	return client.Do(req)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,19 +3,19 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "24CmI1XvvB42B1pV1OhLKecZo2s=",
+			"checksumSHA1": "s8z/bbXTuUvC+gfJBgJ4Jk4k3Oc=",
 			"path": "github.com/aandryashin/matchers",
 			"revision": "5eb67beb188b5076812683a96c13bef79d970fd8",
 			"revisionTime": "2016-07-29T13:19:23Z"
 		},
 		{
-			"checksumSHA1": "6hdqb2Z8iZf/1PcwVAC3e/m6n+E=",
+			"checksumSHA1": "HW6VDC2PRssjIeGiKxYxWNy8Zb4=",
 			"path": "github.com/aandryashin/matchers/httpresp",
 			"revision": "5eb67beb188b5076812683a96c13bef79d970fd8",
 			"revisionTime": "2016-07-29T13:19:23Z"
 		},
 		{
-			"checksumSHA1": "eQlujIDTWnRJjOrfDHYZVznvnew=",
+			"checksumSHA1": "TKKc/+hZZZWr0qkQ/xC9uy7aXJU=",
 			"path": "github.com/abbot/go-http-auth",
 			"revision": "d45c47bedec736d172957bd394786b76626fa8ac",
 			"revisionTime": "2016-12-24T19:38:27Z"
@@ -39,5 +39,5 @@
 			"revisionTime": "2017-01-14T04:22:49Z"
 		}
 	],
-	"rootPath": "github.com/aerokube/ggr"
+	"rootPath": "github.com/adrichem/ggr"
 }


### PR DESCRIPTION
This PR allows Selenium WebDriver on .Net to access ggr. 

Microsoft .Net silently discards the username and password from the URL, presumably due to RFC 3986. So we allow the username and password to be transmitted as part of the desiredCapabilities JSON.