### PR TITLE
Allows guest users to access ggr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/*/
 *.iml
 ggr
 cover.*
+ggr.exe

--- a/docs/cli-flags.adoc
+++ b/docs/cli-flags.adoc
@@ -2,6 +2,10 @@
 
 The following flags are supported by ```ggr``` command:
 ```
+  -guests-allowed
+    	Allow guest (unauthenticated) users to access the grid (default false)
+  -guests-quota
+    	Which quota file to use for guests (default "guest")
   -listen string
     	host and port to listen to (default ":4444")
   -quotaDir string

--- a/main.go
+++ b/main.go
@@ -16,11 +16,13 @@ import (
 )
 
 var (
-	listen         string
-	quotaDir       string
-	users          string
-	timeout        time.Duration
-	gracefulPeriod time.Duration
+	listen             string
+	quotaDir           string
+	users              string
+	timeout            time.Duration
+	gracefulPeriod     time.Duration
+	guestAccessAllowed bool
+	guestUserName      string
 
 	startTime      = time.Now()
 	lastReloadTime = time.Now()
@@ -77,6 +79,8 @@ func fileExists(p string) bool {
 }
 
 func init() {
+	flag.BoolVar(&guestAccessAllowed, "guests-allowed", false, "Allow guest (unauthenticated) users to access the grid")
+	flag.StringVar(&guestUserName, "guests-quota", "guest", "Which quota file to use for guests")
 	flag.StringVar(&listen, "listen", ":4444", "host and port to listen to")
 	flag.StringVar(&quotaDir, "quotaDir", "quota", "quota directory")
 	flag.StringVar(&users, "users", ".htpasswd", "htpasswd auth file path")


### PR DESCRIPTION
As discussed in https://github.com/aerokube/ggr/pull/104 

This runs in addition to Basic Authentication. Administrator can select which quota file to use for guests. All guest session share the same quota.