### PR TITLE
Add missing host information to the http.Request

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -324,6 +324,7 @@ func proxy(r *http.Request) {
 					r.Body = ioutil.NopCloser(bytes.NewReader(body))
 				}
 			}
+			r.Host = h.net()
 			r.URL.Host = h.net()
 			r.URL.Path = proxyPath
 			fragments := strings.Split(proxyPath, "/")


### PR DESCRIPTION
Hi Aerokube team, 

The proxy director should inject the host information
to the request object. This information is expected
with remote selenium hubs.

From the http/request go documentation : "For server
request Host specifies the host on which the URL is sought.
Per RFC 2616, this is either the value of the "Host" header
or the host name given in the URL itself"
See : https://golang.org/src/net/http/request.go