### PR TITLE
Added support of a custom request id for logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ var (
 )
 
 func loadQuotaFiles(quotaDir string) error {
-	log.Printf("[-] [-] [INIT] [-] [-] [-] [-] [-] [-] [Loading configuration files from \"%s\"]\n", quotaDir)
+	log.Printf("[-] [-] [-] [INIT] [-] [-] [-] [-] [-] [-] [Loading configuration files from \"%s\"]\n", quotaDir)
 
 	glob := fmt.Sprintf("%s%c%s", quotaDir, filepath.Separator, "*.xml")
 	files, _ := filepath.Glob(glob)
@@ -54,12 +54,12 @@ func loadQuotaFile(file string) {
 	var browsers Browsers
 	err := readConfig(file, &browsers)
 	if err != nil {
-		log.Printf("[-] [-] [INIT] [-] [-] [-] [-] [-] [-] [Failed to load configuration from \"%s\": %v]\n", fileName, err)
+		log.Printf("[-] [-] [-] [INIT] [-] [-] [-] [-] [-] [-] [Failed to load configuration from \"%s\": %v]\n", fileName, err)
 		return
 	}
 	updateQuota(quotaName, browsers)
 	if verbose {
-		log.Printf("[-] [-] [INIT] [-] [-] [-] [-] [-] [-] [Loaded configuration from \"%s\"]\n%v\n", file, browsers)
+		log.Printf("[-] [-] [-] [INIT] [-] [-] [-] [-] [-] [-] [Loaded configuration from \"%s\"]\n%v\n", file, browsers)
 	}
 }
 
@@ -96,12 +96,12 @@ func init() {
 		showVersion()
 		os.Exit(0)
 	}
-	log.Printf("[-] [-] [INIT] [-] [-] [-] [-] [-] [-] [Users file is \"%s\"]\n", users)
+	log.Printf("[-] [-] [-] [INIT] [-] [-] [-] [-] [-] [-] [Users file is \"%s\"]\n", users)
 	if !fileExists(users) && !guestAccessAllowed {
-		log.Fatalf("[-] [-] [INIT] [-] [-] [-] [-] [-] [-] [Users file \"%s\" does not exist]\n", users)
+		log.Fatalf("[-] [-] [-] [INIT] [-] [-] [-] [-] [-] [-] [Users file \"%s\" does not exist]\n", users)
 	}
 	if err := loadQuotaFiles(quotaDir); err != nil {
-		log.Fatalf("[-] [-] [INIT] [-] [-] [-] [-] [-] [-] [%v]\n", err)
+		log.Fatalf("[-] [-] [-] [INIT] [-] [-] [-] [-] [-] [-] [%v]\n", err)
 	}
 	sig := make(chan os.Signal)
 	signal.Notify(sig, syscall.SIGHUP)
@@ -127,14 +127,14 @@ func main() {
 	}()
 	select {
 	case err := <-e:
-		log.Fatalf("[-] [-] [INIT] [-] [-] [-] [-] [-] [-] [%v]\n", err)
+		log.Fatalf("[-] [-] [-] [INIT] [-] [-] [-] [-] [-] [-] [%v]\n", err)
 	case <-stop:
 	}
 
-	log.Printf("[-] [%s] [SHUTTING_DOWN] [-] [-] [-] [-] [-] [-] [-]\n", gracefulPeriod)
+	log.Printf("[-] [-] [%s] [SHUTTING_DOWN] [-] [-] [-] [-] [-] [-] [-]\n", gracefulPeriod)
 	ctx, cancel := context.WithTimeout(context.Background(), gracefulPeriod)
 	defer cancel()
 	if err := server.Shutdown(ctx); err != nil {
-		log.Fatalf("[-] [-] [SHUTDOWN_FAILURE] [-] [-] [-] [-] [-] [-] [%v]\n", err)
+		log.Fatalf("[-] [-] [-] [SHUTDOWN_FAILURE] [-] [-] [-] [-] [-] [-] [%v]\n", err)
 	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -121,6 +121,10 @@ func (c *caps) browser() string {
 	return c.capability("deviceName")
 }
 
+func (c caps) cRequestId() string {
+		return c.capability("custom.requestId")
+}
+
 func (c caps) version() string {
 	return c.capabilityJsonWireW3C("version", "browserVersion")
 }
@@ -254,15 +258,16 @@ func route(w http.ResponseWriter, r *http.Request) {
 	user, remote := info(r)
 	var c caps
 	err := json.NewDecoder(r.Body).Decode(&c)
+	cRequestId := c.cRequestId()
 	if err != nil {
 		reply(w, errMsg(fmt.Sprintf("bad json format: %s", err.Error())), http.StatusBadRequest)
-		log.Printf("[%d] [%.2fs] [BAD_JSON] [%s] [%s] [-] [-] [-] [-] [%v]\n", id, secondsSince(start), user, remote, err)
+		log.Printf("[%s] [%d] [%.2fs] [BAD_JSON] [%s] [%s] [-] [-] [-] [-] [%v]\n", cRequestId, id, secondsSince(start), user, remote, err)
 		return
 	}
 	browser, version := c.browser(), c.version()
 	if browser == "" {
 		reply(w, errMsg("browser not set"), http.StatusBadRequest)
-		log.Printf("[%d] [%.2fs] [BROWSER_NOT_SET] [%s] [%s] [-] [-] [-] [-] [-]\n", id, secondsSince(start), user, remote)
+		log.Printf("[%s] [%d] [%.2fs] [BROWSER_NOT_SET] [%s] [%s] [-] [-] [-] [-] [-]\n", cRequestId, id, secondsSince(start), user, remote)
 		return
 	}
 	count := 0
@@ -274,7 +279,7 @@ func route(w http.ResponseWriter, r *http.Request) {
 
 	if len(hosts) == 0 {
 		reply(w, errMsg(fmt.Sprintf("unsupported browser: %s", fmtBrowser(browser, version))), http.StatusNotFound)
-		log.Printf("[%d] [%.2fs] [UNSUPPORTED_BROWSER] [%s] [%s] [%s] [-] [-] [-] [-]\n", id, secondsSince(start), user, remote, fmtBrowser(browser, version))
+		log.Printf("[%s] [%d] [%.2fs] [UNSUPPORTED_BROWSER] [%s] [%s] [%s] [-] [-] [-] [-]\n", cRequestId, id, secondsSince(start), user, remote, fmtBrowser(browser, version))
 		return
 	}
 	lastHostError := ""
@@ -288,12 +293,12 @@ loop:
 		if h == nil {
 			break loop
 		}
-		log.Printf("[%d] [%.2fs] [SESSION_ATTEMPTED] [%s] [%s] [%s] [%s] [-] [%d] [-]\n", id, secondsSince(start), user, remote, fmtBrowser(browser, version), h.net(), count)
+		log.Printf("[%s] [%d] [%.2fs] [SESSION_ATTEMPTED] [%s] [%s] [%s] [%s] [-] [%d] [-]\n", cRequestId, id, secondsSince(start), user, remote, fmtBrowser(browser, version), h.net(), count)
 		c.setVersion(version)
 		resp, status := h.session(r.Context(), r.Header, c)
 		select {
 		case <-r.Context().Done():
-			log.Printf("[%d] [%.2fs] [CLIENT_DISCONNECTED] [%s] [%s] [%s] [%s] [-] [%d] [-]\n", id, secondsSince(start), user, remote, fmtBrowser(browser, version), h.net(), count)
+			log.Printf("[%s] [%d] [%.2fs] [CLIENT_DISCONNECTED] [%s] [%s] [%s] [%s] [-] [%d] [-]\n", cRequestId, id, secondsSince(start), user, remote, fmtBrowser(browser, version), h.net(), count)
 			return
 		default:
 		}
@@ -303,7 +308,7 @@ loop:
 			if !ok {
 				protocolError := func() {
 					reply(w, errMsg("protocol error"), http.StatusBadGateway)
-					log.Printf("[%d] [%.2fs] [BAD_RESPONSE] [%s] [%s] [%s] [%s] [-] [-] [-]\n", id, secondsSince(start), user, remote, fmtBrowser(browser, version), h.net())
+					log.Printf("[%s] [%d] [%.2fs] [BAD_RESPONSE] [%s] [%s] [%s] [%s] [-] [-] [-]\n", cRequestId, id, secondsSince(start), user, remote, fmtBrowser(browser, version), h.net())
 				}
 				value, ok := resp["value"]
 				if !ok {
@@ -320,7 +325,7 @@ loop:
 				resp["sessionId"] = h.sum() + sess
 			}
 			reply(w, resp, http.StatusOK)
-			log.Printf("[%d] [%.2fs] [SESSION_CREATED] [%s] [%s] [%s] [%s] [%s] [%d] [-]\n", id, secondsSince(start), user, remote, fmtBrowser(browser, version), h.net(), sess, count)
+			log.Printf("[%s] [%d] [%.2fs] [SESSION_CREATED] [%s] [%s] [%s] [%s] [%s] [%d] [-]\n", cRequestId, id, secondsSince(start), user, remote, fmtBrowser(browser, version), h.net(), sess, count)
 			return
 		case browserFailed:
 			hosts = append(hosts[:i], hosts[i+1:]...)
@@ -330,7 +335,7 @@ loop:
 			hosts, version, excludedRegions = browsers.find(browser, version, excludedHosts, excludedRegions)
 		}
 		errMsg := browserErrMsg(resp)
-		log.Printf("[%d] [%.2fs] [SESSION_FAILED] [%s] [%s] [%s] [%s] [-] [%d] [%s]\n", id, secondsSince(start), user, remote, fmtBrowser(browser, version), h.net(), count, errMsg)
+		log.Printf("[%s] [%d] [%.2fs] [SESSION_FAILED] [%s] [%s] [%s] [%s] [-] [%d] [%s]\n", cRequestId, id, secondsSince(start), user, remote, fmtBrowser(browser, version), h.net(), count, errMsg)
 		lastHostError = errMsg
 		if len(hosts) == 0 {
 			break loop
@@ -341,7 +346,7 @@ loop:
 		notCreatedMsg = fmt.Sprintf("%s, last host error was: %s", notCreatedMsg, lastHostError)
 	}
 	reply(w, errMsg(notCreatedMsg), http.StatusInternalServerError)
-	log.Printf("[%d] [%.2fs] [SESSION_NOT_CREATED] [%s] [%s] [%s] [-] [-] [-] [-]\n", id, secondsSince(start), user, remote, fmtBrowser(browser, version))
+	log.Printf("[%s] [%d] [%.2fs] [SESSION_NOT_CREATED] [%s] [%s] [%s] [-] [-] [-] [-]\n", cRequestId, id, secondsSince(start), user, remote, fmtBrowser(browser, version))
 }
 
 func secondsSince(start time.Time) float64 {
@@ -377,16 +382,16 @@ func proxy(r *http.Request) {
 			fragments := strings.Split(proxyPath, "/")
 			sess := fragments[sessPart]
 			if verbose {
-				log.Printf("[%d] [-] [PROXYING] [-] [%s] [-] [%s] [%s] [-] [%s]\n", id, remote, h.net(), sess, proxyPath)
+				log.Printf("[-] [%d] [-] [PROXYING] [-] [%s] [-] [%s] [%s] [-] [%s]\n", id, remote, h.net(), sess, proxyPath)
 			}
 			if r.Method == http.MethodDelete && len(fragments) == sessPart+1 {
-				log.Printf("[%d] [-] [SESSION_DELETED] [-] [%s] [-] [%s] [%s] [-] [-]\n", id, remote, h.net(), sess)
+				log.Printf("[-] [%d] [-] [SESSION_DELETED] [-] [%s] [-] [%s] [%s] [-] [-]\n", id, remote, h.net(), sess)
 			}
 			return
 		}
-		log.Printf("[%d] [-] [ROUTE_NOT_FOUND] [-] [%s] [%s] [-] [-] [-] [-]\n", id, remote, proxyPath)
+		log.Printf("[-] [%d] [-] [ROUTE_NOT_FOUND] [-] [%s] [%s] [-] [-] [-] [-]\n", id, remote, proxyPath)
 	} else {
-		log.Printf("[%d] [-] [INVALID_URL] [-] [%s] [%s] [-] [-] [-] [-]\n", id, remote, r.URL.Path)
+		log.Printf("[-] [%d] [-] [INVALID_URL] [-] [%s] [%s] [-] [-] [-] [-]\n", id, remote, r.URL.Path)
 	}
 	r.URL.Host = listen
 	r.URL.Path = errPath
@@ -429,7 +434,7 @@ func host(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("unknown host"))
 		return
 	}
-	log.Printf("[%d] [-] [HOST_INFO_REQUESTED] [%s] [%s] [-] [%s] [%s] [-] [-]\n", id, user, remote, h.Name, sum)
+	log.Printf("[-] [%d] [-] [HOST_INFO_REQUESTED] [%s] [%s] [-] [%s] [%s] [-] [-]\n", id, user, remote, h.Name, sum)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(Host{Name: h.Name, Port: h.Port, Count: h.Count})
 }
@@ -439,7 +444,7 @@ func quotaInfo(w http.ResponseWriter, r *http.Request) {
 	defer confLock.RUnlock()
 	id := serial()
 	user, remote := info(r)
-	log.Printf("[%d] [-] [QUOTA_INFO_REQUESTED] [%s] [%s] [-] [-] [-] [-] [-]\n", id, user, remote)
+	log.Printf("[-] [%d] [-] [QUOTA_INFO_REQUESTED] [%s] [%s] [-] [-] [-] [-] [-]\n", id, user, remote)
 	browsers := quota[user]
 	w.Header().Set("Content-Type", "application/json")
 	// NOTE: intentionally not removing username \ password fields from returned XML to not complicate things (can be done later if needed)
@@ -503,11 +508,11 @@ func createVNCInfo(h Host) *vncInfo {
 	if vncURL != "" {
 		u, err := url.Parse(vncURL)
 		if err != nil {
-			log.Printf("[-] [-] [INVALID_HOST_VNC_URL] [-] [-] [%s] [%s] [-] [-] [-]\n", vncURL, fmt.Sprintf("%s:%d", h.Name, h.Port))
+			log.Printf("[-] [-] [-] [INVALID_HOST_VNC_URL] [-] [-] [%s] [%s] [-] [-] [-]\n", vncURL, fmt.Sprintf("%s:%d", h.Name, h.Port))
 			return nil
 		}
 		if u.Scheme != vncScheme && u.Scheme != wsScheme {
-			log.Printf("[-] [-] [UNSUPPORTED_HOST_VNC_SCHEME] [-] [-] [%s] [%s] [-] [-] [-]\n", vncURL, fmt.Sprintf("%s:%d", h.Name, h.Port))
+			log.Printf("[-] [-] [-] [UNSUPPORTED_HOST_VNC_SCHEME] [-] [-] [%s] [%s] [-] [-] [-]\n", vncURL, fmt.Sprintf("%s:%d", h.Name, h.Port))
 			return nil
 		}
 		vncInfo := vncInfo{
@@ -560,7 +565,7 @@ func vnc(wsconn *websocket.Conn) {
 	tail := head + md5SumLength
 	path := wsconn.Request().URL.Path
 	if len(path) < tail {
-		log.Printf("[%d] [-] [INVALID_VNC_REQUEST_URL] [-] [-] [%s] [-] [-] [-] [-]\n", id, path)
+		log.Printf("[-] [%d] [-] [INVALID_VNC_REQUEST_URL] [-] [-] [%s] [-] [-] [-] [-]\n", id, path)
 		return
 	}
 	sum := path[head:tail]
@@ -585,12 +590,12 @@ func vnc(wsconn *websocket.Conn) {
 			proxyWebSockets(id, wsconn, sessionID, host, port, path)
 		default:
 			{
-				log.Printf("[%d] [-] [UNSUPPORTED_HOST_VNC_SCHEME] [-] [-] [%s] [-] [-] [-] [-]\n", id, scheme)
+				log.Printf("[-] [%d] [-] [UNSUPPORTED_HOST_VNC_SCHEME] [-] [-] [%s] [-] [-] [-] [-]\n", id, scheme)
 				return
 			}
 		}
 	} else {
-		log.Printf("[%d] [-] [UNKNOWN_VNC_HOST] [-] [-] [-] [-] [%s] [-] [-]\n", id, sum)
+		log.Printf("[-] [%d] [-] [UNKNOWN_VNC_HOST] [-] [-] [-] [-] [%s] [-] [-]\n", id, sum)
 	}
 
 }
@@ -611,9 +616,9 @@ func proxyWebSockets(id uint64, wsconn *websocket.Conn, sessionID string, host s
 }
 
 func proxyConn(id uint64, wsconn *websocket.Conn, conn net.Conn, err error, sessionID string, address string) {
-	log.Printf("[%d] [-] [PROXYING_TO_VNC] [-] [-] [-] [%s] [%s] [-] [-]\n", id, address, sessionID)
+	log.Printf("[-] [%d] [-] [PROXYING_TO_VNC] [-] [-] [-] [%s] [%s] [-] [-]\n", id, address, sessionID)
 	if err != nil {
-		log.Printf("[%d] [-] [VNC_ERROR] [-] [-] [-] [%s] [%s] [-] [%v]\n", id, sessionID, address, err)
+		log.Printf("[-] [%d] [-] [VNC_ERROR] [-] [-] [-] [%s] [%s] [-] [%v]\n", id, sessionID, address, err)
 		return
 	}
 	defer conn.Close()
@@ -621,10 +626,10 @@ func proxyConn(id uint64, wsconn *websocket.Conn, conn net.Conn, err error, sess
 	go func() {
 		io.Copy(wsconn, conn)
 		wsconn.Close()
-		log.Printf("[%d] [-] [VNC_SESSION_CLOSED] [-] [-] [-] [%s] [%s] [-] [-]\n", id, address, sessionID)
+		log.Printf("[-] [%d] [-] [VNC_SESSION_CLOSED] [-] [-] [-] [%s] [%s] [-] [-]\n", id, address, sessionID)
 	}()
 	io.Copy(conn, wsconn)
-	log.Printf("[%d] [-] [VNC_CLIENT_DISCONNECTED] [-] [-] [-] [%s] [%s] [-] [-]\n", id, address, sessionID)
+	log.Printf("[-] [%d] [-] [VNC_CLIENT_DISCONNECTED] [-] [-] [-] [%s] [%s] [-] [-]\n", id, address, sessionID)
 }
 
 func video(w http.ResponseWriter, r *http.Request) {
@@ -637,7 +642,7 @@ func video(w http.ResponseWriter, r *http.Request) {
 	tail := head + md5SumLength
 	path := r.URL.Path
 	if len(path) < tail {
-		log.Printf("[%d] [-] [INVALID_VIDEO_REQUEST_URL] [%s] [%s] [%s] [-] [-] [-] [-]\n", id, user, remote, path)
+		log.Printf("[-] [%d] [-] [INVALID_VIDEO_REQUEST_URL] [%s] [%s] [%s] [-] [-] [-] [-]\n", id, user, remote, path)
 		reply(w, errMsg("invalid video request URL"), http.StatusNotFound)
 		return
 	}
@@ -649,10 +654,10 @@ func video(w http.ResponseWriter, r *http.Request) {
 			r.URL.Scheme = "http"
 			r.URL.Host = h.net()
 			r.URL.Path = fmt.Sprintf("/video/%s.mp4", sessionID)
-			log.Printf("[%d] [-] [PROXYING_VIDEO] [%s] [%s] [%s] [-] [%s] [-] [-]\n", id, user, remote, r.URL, sessionID)
+			log.Printf("[-] [%d] [-] [PROXYING_VIDEO] [%s] [%s] [%s] [-] [%s] [-] [-]\n", id, user, remote, r.URL, sessionID)
 		}}).ServeHTTP(w, r)
 	} else {
-		log.Printf("[%d] [-] [UNKNOWN_VIDEO_HOST] [%s] [%s] [-] [-] [%s] [-] [-]\n", id, user, remote, sum)
+		log.Printf("[-] [%d] [-] [UNKNOWN_VIDEO_HOST] [%s] [%s] [-] [-] [%s] [-] [-]\n", id, user, remote, sum)
 		reply(w, errMsg("unknown video host"), http.StatusNotFound)
 	}
 }


### PR DESCRIPTION
Adds ability to associate a specific ggr log message with the original WebDriver request.

Use: User puts a custom request id into the Desired Capabilities of his WebDriver, ggr logs the id and lets the user associate the log message with his original request.