### PR TITLE
Allowing quota reload through API call

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1399,6 +1399,13 @@ func TestStartSessionGuestModeAndWrongBasicAuth(t *testing.T) {
 	AssertThat(t, rsp.StatusCode, Is{http.StatusUnauthorized})
 }
 
+func TestReloadWithoutAuth(t *testing.T) {
+	rsp, err := http.Post(gridrouter("/reload"), "", bytes.NewReader([]byte(`{"desiredCapabilities":{}}`)))
+
+	AssertThat(t, err, Is{nil})
+	AssertThat(t, rsp, Code{http.StatusUnauthorized})
+}
+
 func createSessionWithoutAuthentication(capabilities string) (*http.Response, error) {
 	body := bytes.NewReader([]byte(capabilities))
 	return doHTTPRequestWithoutAuthentication(http.MethodPost, gridrouter("/wd/hub/session"), body)


### PR DESCRIPTION
I am using GGR to load balance a Selenoid grid running in Docker Swarm.  As nodes in the Swarm can change over time, I have developed a way to keep the GGR config file updated, however, I am unable to use `docker kill -s` to send a signal to containers running in the Swarm.

This PR allows authenticated users to `POST` to `/reload` to have GGR reload its config.