### PR TITLE
Add auth headers to vnc connections

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"encoding/base64"
 
 	. "github.com/aerokube/ggr/config"
 	"golang.org/x/net/websocket"

--- a/proxy.go
+++ b/proxy.go
@@ -710,7 +710,7 @@ func setupAuthWS(config *websocket.Config, username string, password string) {
 		return
 	}
 	auth := base64.URLEncoding.EncodeToString([]byte(username + ":" + password))
-	config.Header.Add("Authorization", "Basic "+auth)
+	config.Header.Set("Authorization", "Basic "+auth)
 }
 
 func setupAuthHttp(r *http.Request, username string, password string) {
@@ -718,7 +718,7 @@ func setupAuthHttp(r *http.Request, username string, password string) {
 		return
 	}
 	auth := base64.URLEncoding.EncodeToString([]byte(username + ":" + password))
-	r.Header.Add("Authorization", "Basic "+auth)
+	r.Header.Set("Authorization", "Basic "+auth)
 }
 
 func proxyConn(id uint64, wsconn *websocket.Conn, conn net.Conn, err error, sessionID string, address string) {

--- a/proxy.go
+++ b/proxy.go
@@ -694,7 +694,7 @@ func proxyVNC(id uint64, wsconn *websocket.Conn, sessionID string, host string, 
 func proxyWebSockets(id uint64, wsconn *websocket.Conn, sessionID string, scheme string, host string, port string, path string, username string, password string) {
 	origin := "http://localhost/"
 	u := fmt.Sprintf("%s://%s:%s%s/%s", scheme, host, port, path, sessionID)
-	config, err := websocket.NewConfig(u.String(), origin)
+	config, err := websocket.NewConfig(u, origin)
 	if err != nil {
 		log.Printf("[WEBSOCKET] [Failed to create websocket config %s: %v]", u, err)
 		return

--- a/proxy.go
+++ b/proxy.go
@@ -420,7 +420,7 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 					sess := fragments[sessPart]
 					setupAuthHttp(r, h.Username, h.Password)
 					if verbose {
-						log.Printf("[%d] [-] [PROXYING] [-] [%s] [-] [%s] [%s] [-] [%s]\n", id, remote, h.Net(), sess, proxyPath)
+						log.Printf("[%d] [-] [PROXYING] [-] [%s] [-] [%s] [-] [%s] [%s] [-] [%s]\n", id, r.URL.String(), remote, h.Net(), sess, proxyPath)
 					}
 					if r.Method == http.MethodDelete && len(fragments) == sessPart+1 {
 						log.Printf("[%d] [-] [SESSION_DELETED] [-] [%s] [-] [%s] [%s] [-] [-]\n", id, remote, h.Net(), sess)

--- a/proxy.go
+++ b/proxy.go
@@ -512,8 +512,8 @@ func quotaInfo(w http.ResponseWriter, r *http.Request) {
 				region := &version.Regions[k]
 				for l := 0; l < len(region.Hosts); l++ {
 					host := &region.Hosts[l]
-					host.Username = ""
-					host.Password = ""
+					host.Username = "" + host.Username
+					host.Password = "" + host.Password
 				}
 			}
 		}

--- a/proxy.go
+++ b/proxy.go
@@ -419,8 +419,11 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 					fragments := strings.Split(proxyPath, "/")
 					sess := fragments[sessPart]
 					setupAuthHttp(r, h.Username, h.Password)
+					log.Printf("verbose start")
 					if verbose {
+						log.Printf("verbose if")
 						log.Printf("[%d] [-] [PROXYING] [-] [%s] [-] [%s] [-] [%s] [%s] [-] [%s]\n", id, r.URL.String(), remote, h.Net(), sess, proxyPath)
+						log.Printf("verbose end")
 					}
 					if r.Method == http.MethodDelete && len(fragments) == sessPart+1 {
 						log.Printf("[%d] [-] [SESSION_DELETED] [-] [%s] [-] [%s] [%s] [-] [-]\n", id, remote, h.Net(), sess)

--- a/proxy.go
+++ b/proxy.go
@@ -514,8 +514,8 @@ func quotaInfo(w http.ResponseWriter, r *http.Request) {
 				region := &version.Regions[k]
 				for l := 0; l < len(region.Hosts); l++ {
 					host := &region.Hosts[l]
-					host.Username = ""
-					host.Password = ""
+					host.Username = "" + host.Username
+					host.Password = "" + host.Password
 				}
 			}
 		}

--- a/proxy.go
+++ b/proxy.go
@@ -419,11 +419,8 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 					fragments := strings.Split(proxyPath, "/")
 					sess := fragments[sessPart]
 					setupAuthHttp(r, h.Username, h.Password)
-					log.Printf("verbose start")
 					if verbose {
-						log.Printf("verbose if")
-						log.Printf("[%d] [-] [PROXYING] [-] [%s] [-] [%s] [-] [%s] [%s] [-] [%s]\n", id, r.URL.String(), remote, h.Net(), sess, proxyPath)
-						log.Printf("verbose end")
+						log.Printf("[%d] [-] [PROXYING] [-] [%s] [-] [%s] [-] [%s] [-] [%s]\n", id, remote, sess, proxyPath, r.URL.String())
 					}
 					if r.Method == http.MethodDelete && len(fragments) == sessPart+1 {
 						log.Printf("[%d] [-] [SESSION_DELETED] [-] [%s] [-] [%s] [%s] [-] [-]\n", id, remote, h.Net(), sess)

--- a/proxy.go
+++ b/proxy.go
@@ -699,7 +699,7 @@ func proxyWebSockets(id uint64, wsconn *websocket.Conn, sessionID string, scheme
 		log.Printf("[WEBSOCKET] [Failed to create websocket config %s: %v]", u, err)
 		return
 	}
-	setupAuth(config, host.Username, host.Password)
+	setupAuth(config, username, password)
 	conn, err := websocket.DialConfig(config)
 	proxyConn(id, wsconn, conn, err, sessionID, u)
 }

--- a/proxy.go
+++ b/proxy.go
@@ -512,8 +512,8 @@ func quotaInfo(w http.ResponseWriter, r *http.Request) {
 				region := &version.Regions[k]
 				for l := 0; l < len(region.Hosts); l++ {
 					host := &region.Hosts[l]
-					host.Username = "" + host.Username
-					host.Password = "" + host.Password
+					host.Username = ""
+					host.Password = ""
 				}
 			}
 		}

--- a/proxy.go
+++ b/proxy.go
@@ -580,7 +580,7 @@ func createVNCInfo(h Host) *VncInfo {
 			log.Printf("[-] [-] [INVALID_HOST_VNC_URL] [-] [-] [%s] [%s] [-] [-] [-]\n", vncURL, fmt.Sprintf("%s:%d", h.Name, h.Port))
 			return nil
 		}
-		if u.Scheme != vncScheme && u.Scheme != wsScheme {
+		if u.Scheme != vncScheme && u.Scheme != wsScheme && u.Scheme != (wsScheme + "s") {
 			log.Printf("[-] [-] [UNSUPPORTED_HOST_VNC_SCHEME] [-] [-] [%s] [%s] [-] [-] [-]\n", vncURL, fmt.Sprintf("%s:%d", h.Name, h.Port))
 			return nil
 		}

--- a/proxy.go
+++ b/proxy.go
@@ -787,7 +787,11 @@ func proxyStatic(w http.ResponseWriter, r *http.Request, route string, invalidUr
 	if ok {
 		(&httputil.ReverseProxy{
 			Director: func(r *http.Request) {
-				r.URL.Scheme = "http"
+				if h.Scheme != "" {
+					r.URL.Scheme = h.Scheme
+				} else {
+					r.URL.Scheme = "http"
+				}
 				r.URL.Host = h.Net()
 				r.URL.Path = pathProvider(remainder)
 				setupAuthHttp(r, h.Username, h.Password)

--- a/proxy.go
+++ b/proxy.go
@@ -790,6 +790,7 @@ func proxyStatic(w http.ResponseWriter, r *http.Request, route string, invalidUr
 				r.URL.Scheme = "http"
 				r.URL.Host = h.Net()
 				r.URL.Path = pathProvider(remainder)
+				setupAuthHttp(r, h.Username, h.Password)
 				log.Printf("[%d] [-] [%s] [%s] [%s] [%s] [-] [%s] [-] [-]\n", id, proxyingMessage, user, remote, r.URL, remainder)
 			},
 			ErrorHandler: defaultErrorHandler(id),


### PR DESCRIPTION
Right now usernames, passwords, and wss urls are ignored in the quota file when connecting to VNC. I've added a couple of methods that will add an authorization header and use WSS when required.