### PR TITLE
implement Selenium 4 CDP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 ggr
 coverage.*
 ggr.exe
+.vscode


### PR DESCRIPTION
Hi @vania-pooh,
This is an implementation of supporting new selenium 4 cdp proxying. 
a new selenium 4 grid is able to proxy CDP WebSocket from the node through the hub out of the box, So I wanted to have this possibility in GGR as well - as we use GGR and it works great for us.
it is pretty much based on VNC, with some tweaks.

Please let me know what I should do to get this PR approved and merged - if there are any documentation/tests missing etc.