### PR TITLE
selenium 4: charset=utf-8 on session creating

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -204,7 +204,7 @@ func session(ctx context.Context, h *Host, header http.Header, c caps) (map[stri
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	req = req.WithContext(ctx)
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	resp, err := httpClient.Do(req)
 	if resp != nil {
 		defer resp.Body.Close()


### PR DESCRIPTION
#355 fixed issue `Content-Type header does not indicate utf-8 encoded json: application/json` with selenium grid 4