### PR TITLE
Fix for #284 - Match platform without considering case

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,7 +58,7 @@ func (b *ggrBrowsers) find(browser, version string, platform string, excludedHos
 				platform = b.DefaultPlatform
 			}
 			for _, v := range b.Versions {
-				if strings.HasPrefix(v.Number, version) && (v.Platform == "" || strings.HasPrefix(v.Platform, platform)) {
+				if strings.HasPrefix(v.Number, version) && (v.Platform == "" || strings.HasPrefix(strings.ToLower(v.Platform), strings.ToLower(platform))) {
 					version = v.Number
 				next:
 					for _, r := range v.Regions {

--- a/config_test.go
+++ b/config_test.go
@@ -158,6 +158,13 @@ func TestFindWithPlatform(t *testing.T) {
 	AssertThat(t, hosts[0].Name, EqualTo{"browser-2.0-linux"})
 }
 
+func TestFindWithPlatformLowercase(t *testing.T) {
+	hosts, version, _ := browsersWithMultiplePlatforms.find("browser", "2.0", "windows", newSet(), newSet())
+	AssertThat(t, version, EqualTo{"2.0"})
+	AssertThat(t, len(hosts), EqualTo{1})
+	AssertThat(t, hosts[0].Name, EqualTo{"browser-2.0-windows"})
+}
+
 func TestFindWithPlatformPrefix(t *testing.T) {
 	hosts, version, _ := browsersWithMultiplePlatforms.find("browser", "2.0", "WIN", newSet(), newSet())
 	AssertThat(t, version, EqualTo{"2.0"})


### PR DESCRIPTION
It looks like Selenium 4 and Selenium 3 submit "platform" capability differently: 

- for the 3rd version it's upper-case (e.g. "chrome-107.0-LINUX")
- for the 4th version it's lower-case (e.g. "chrome-107.0-linux")

We want our GGR server to work with both Selenium versions, so I used `strings.ToLower` for platform filtering to become case insensitive. 