### PR TITLE
Response is not-nil if error is nil

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -210,12 +210,10 @@ func session(ctx context.Context, h *Host, header http.Header, c caps) (map[stri
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	resp, err := httpClient.Do(req)
-	if resp != nil {
-		defer resp.Body.Close()
-	}
 	if err != nil {
 		return nil, seleniumError
 	}
+	defer resp.Body.Close()
 	location := resp.Header.Get("Location")
 	if location != "" {
 		l, err := url.Parse(location)


### PR DESCRIPTION
This PR removes `if resp != nil` check when creating a session in `proxy.go`.

The `resp` object cannot be `nil` in this code, as it is assigned the return value of `httpClient.Do(req)` method call, which returns a non-nil response object or an `error if the request could not be sent or the server returns an error response. From the [documentation](https://pkg.go.dev/net/http#Client.Do):
> If the returned error is nil, the Response will contain a non-nil Body which the user is expected to close.
> ...
> The request Body, if non-nil, will be closed by the underlying Transport, even on errors.

Actually, the code has leaked resources, but in `proxy_test.go`. Every call to `http.Get` must be accompanied by `rsp.Body.Close()` call. These places can be found by [bodyclose](https://github.com/timakin/bodyclose) linter.
